### PR TITLE
Create URL resource type.

### DIFF
--- a/policy/.support.sh
+++ b/policy/.support.sh
@@ -36,7 +36,7 @@ post_request() {
     -X POST \
     -H 'Accept: application/json' \
     -H 'Content-Type: application/json' \
-    -H 'Accept-API-Version: protocol=1.0,resource=2.0' \
+    -H 'Accept-API-Version: protocol=1.0' \
     -H "iPlanetDirectoryPro: $TOKEN" \
     -d @- \
     --connect-to wrenam.wrensecurity.local:80:10.0.0.11:80 \

--- a/policy/01-create-policy.sh
+++ b/policy/01-create-policy.sh
@@ -10,6 +10,28 @@ TEST_USER_PASSWORD=password
 
 TOKEN=$(authenticate "/")
 
+# Create URL resource type
+URL_RESOURCE_TYPE_DATA='{
+  "uuid": "UrlResourceType",
+  "name": "URL",
+  "actions": {
+    "DELETE" : true,
+    "GET" : true,
+    "HEAD" : true,
+    "OPTIONS" : true,
+    "PATCH" : true,
+    "POST" : true,
+    "PUT" : true
+  },
+  "patterns": [
+    "*://*:*/*",
+    "*://*:*/*?*"
+  ]
+}'
+post_request "resourcetypes" "create" <<< "$URL_RESOURCE_TYPE_DATA" \
+  | assert_response_status 201 \
+  > /dev/null
+
 # Create policy set
 TEST_POLICY_SET_DATA='{
   "name": "'$TEST_POLICY_SET_ID'",


### PR DESCRIPTION
This commit adds the creation of the URL resource type, as it is no longer created automatically (see https://github.com/WrenSecurity/wrenam/commit/6aee2a59a5ef5dbfc91859338b0c4b78c765929b).